### PR TITLE
Initial description of font interface

### DIFF
--- a/face.go
+++ b/face.go
@@ -31,8 +31,8 @@ type FaceMetrics interface {
 	// string if the glyph is invalid or has no name.
 	GlyphName(glyph GID) string
 
-	// FontHExtents returns the extents of the font for horizontal text, or false
-	// it not available, in font units.
+	// FontHExtents returns the extents of the font for horizontal text in font units,
+	// or false if not available.
 	// `varCoords` (in normalized coordinates) is only useful for variable fonts.
 	FontHExtents(varCoords []float32) (FontExtents, bool)
 

--- a/face.go
+++ b/face.go
@@ -1,3 +1,102 @@
+// Package font provides supports for parsing
+// several font formats (postscript, bitmap and truetype)
+// and provides a common API.
+//
+// It provides low-level metric information used by shaping
+// engines and a way of rendering outline and bitmap glyphs.
 package font
 
-type Face interface{}
+// Face is the common interface to represent various font formats.
+//
+// A Face object is the in-memory representation of a font file:
+// as such it does not hold scaling information.
+//
+// Complex font features may require an extension interface :
+// see opentype.FaceOpentype for an example.
+type Face interface {
+	FaceMetrics
+	FaceRenderer
+}
+
+// FaceMetrics exposes the information about a font file
+// required by a layout engine.
+// All the returned metrics are expressed in font units
+// and should be scaled.
+type FaceMetrics interface {
+	// Upem returns the units per em of the font file.
+	// If not found, should return 1000 as fallback value.
+	Upem() uint16
+
+	// GlyphName returns the name of the given glyph, or an empty
+	// string if the glyph is invalid or has no name.
+	GlyphName(glyph GID) string
+
+	// FontHExtents returns the extents of the font for horizontal text, or false
+	// it not available, in font units.
+	// `varCoords` (in normalized coordinates) is only useful for variable fonts.
+	FontHExtents(varCoords []float32) (FontExtents, bool)
+
+	// FontVExtents is the same as `FontHExtents`, but for vertical text.
+	FontVExtents(varCoords []float32) (FontExtents, bool)
+
+	// NominalGlyph returns the glyph used to represent the given rune,
+	// or false if not found.
+	NominalGlyph(ch rune) (GID, bool)
+
+	// HorizontalAdvance returns the horizontal advance in font units.
+	// When no data is available but the glyph index is valid, this method
+	// should return a default value (the upem number for example).
+	// If the glyph is invalid it should return 0.
+	// `varCoords` is used by variable fonts, and is specified in normalized coordinates.
+	HorizontalAdvance(glyph GID, varCoords []float32) float32
+
+	// VerticalAdvance is the same as `HorizontalAdvance`, but for vertical advance.
+	VerticalAdvance(glyph GID, varCoords []float32) float32
+
+	// GlyphHOrigin fetches the (X,Y) coordinates of the origin (in font units) for a glyph ID,
+	// for horizontal text segments.
+	// Returns `false` if not available.
+	GlyphHOrigin(glyph GID, varCoords []float32) (x, y int32, found bool)
+
+	// GlyphVOrigin is the same as `GlyphHOrigin`, but for vertical text segments.
+	GlyphVOrigin(glyph GID, varCoords []float32) (x, y int32, found bool)
+
+	// GlyphExtents retrieve the extents for a specified glyph, of false, if not available.
+	// `varCoords` is used by variable fonts, and is specified in normalized coordinates.
+	// For bitmap glyphs, the closest resolution to `xPpem` and `yPpem` is selected.
+	GlyphExtents(glyph GID, varCoords []float32, xPpem, yPpem uint16) (GlyphExtents, bool)
+
+	// NormalizeVariations should normalize the given design-space coordinates. The minimum and maximum
+	// values for the axis are mapped to the interval [-1,1], with the default
+	// axis value mapped to 0.
+	// This should be a no-op for non-variable fonts.
+	NormalizeVariations(varCoords []float32) []float32
+}
+
+// FaceRenderer implements the drawing of glyphs.
+type FaceRenderer interface {
+	// TODO: add position information and output/destination
+	Draw(glyph GID)
+}
+
+// GID is used to identify glyphs in a font.
+// It is mostly internal to the font and should not be confused with
+// Unicode code points.
+type GID uint32
+
+// FontExtents exposes font-wide extent values, measured in font units.
+// Note that typically ascender is positive and descender negative in coordinate systems that grow up.
+type FontExtents struct {
+	Ascender  float32 // Typographic ascender.
+	Descender float32 // Typographic descender.
+	LineGap   float32 // Suggested line spacing gap.
+}
+
+// GlyphExtents exposes extent values, measured in font units.
+// Note that height is negative in coordinate systems that grow up.
+type GlyphExtents struct {
+	XBearing float32 // Left side of glyph from origin
+	YBearing float32 // Top side of glyph from origin
+	Width    float32 // Distance from left to right side
+	Height   float32 // Distance from top to bottom side
+}

--- a/face.go
+++ b/face.go
@@ -34,10 +34,10 @@ type FaceMetrics interface {
 	// FontHExtents returns the extents of the font for horizontal text in font units,
 	// or false if not available.
 	// `varCoords` (in normalized coordinates) is only useful for variable fonts.
-	FontHExtents(varCoords []float32) (FontExtents, bool)
+	FontHExtents() (FontExtents, bool)
 
 	// FontVExtents is the same as `FontHExtents`, but for vertical text.
-	FontVExtents(varCoords []float32) (FontExtents, bool)
+	FontVExtents() (FontExtents, bool)
 
 	// NominalGlyph returns the glyph used to represent the given rune,
 	// or false if not found.
@@ -48,29 +48,23 @@ type FaceMetrics interface {
 	// should return a default value (the upem number for example).
 	// If the glyph is invalid it should return 0.
 	// `varCoords` is used by variable fonts, and is specified in normalized coordinates.
-	HorizontalAdvance(glyph GID, varCoords []float32) float32
+	HorizontalAdvance(glyph GID) float32
 
 	// VerticalAdvance is the same as `HorizontalAdvance`, but for vertical advance.
-	VerticalAdvance(glyph GID, varCoords []float32) float32
+	VerticalAdvance(glyph GID) float32
 
 	// GlyphHOrigin fetches the (X,Y) coordinates of the origin (in font units) for a glyph ID,
 	// for horizontal text segments.
 	// Returns `false` if not available.
-	GlyphHOrigin(glyph GID, varCoords []float32) (x, y int32, found bool)
+	GlyphHOrigin(glyph GID) (x, y int32, found bool)
 
 	// GlyphVOrigin is the same as `GlyphHOrigin`, but for vertical text segments.
-	GlyphVOrigin(glyph GID, varCoords []float32) (x, y int32, found bool)
+	GlyphVOrigin(glyph GID) (x, y int32, found bool)
 
 	// GlyphExtents retrieve the extents for a specified glyph, of false, if not available.
 	// `varCoords` is used by variable fonts, and is specified in normalized coordinates.
 	// For bitmap glyphs, the closest resolution to `xPpem` and `yPpem` is selected.
-	GlyphExtents(glyph GID, varCoords []float32, xPpem, yPpem uint16) (GlyphExtents, bool)
-
-	// NormalizeVariations should normalize the given design-space coordinates. The minimum and maximum
-	// values for the axis are mapped to the interval [-1,1], with the default
-	// axis value mapped to 0.
-	// This should be a no-op for non-variable fonts.
-	NormalizeVariations(varCoords []float32) []float32
+	GlyphExtents(glyph GID, xPpem, yPpem uint16) (GlyphExtents, bool)
 }
 
 // FaceRenderer implements the drawing of glyphs.

--- a/opentype/opentype.go
+++ b/opentype/opentype.go
@@ -16,9 +16,23 @@ type FaceOpentype interface {
 	// TablesLayout fetches the advanced Opentype and AAT layout tables of the font.
 	TablesLayout() TablesLayout
 
-	// Variations returns the variations for the font,
-	// or an empty table.
+	// Variations returns the 'fvar' table (maybe empty).
 	Variations() TableFvar
+
+	// SetVarCoordinates apply the normalized coordinates values.
+	// Use `NormalizeVariations` to convert from design space units.
+	// See also `SetVariations`.
+	SetVarCoordinates(coords []float32)
+
+	// VarCoordinates returns the current variable coordinates,
+	// in normalized units.
+	VarCoordinates() []float32
+
+	// NormalizeVariations should normalize the given design-space coordinates. The minimum and maximum
+	// values for the axis are mapped to the interval [-1,1], with the default
+	// axis value mapped to 0.
+	// This should be a no-op for non-variable fonts.
+	NormalizeVariations(coords []float32) []float32
 
 	// IsGraphite returns true if the font has Graphite capabilities.
 	// The returned Face will be used to load Graphite tables.

--- a/opentype/opentype.go
+++ b/opentype/opentype.go
@@ -23,7 +23,7 @@ type FaceOpentype interface {
 	// IsGraphite returns true if the font has Graphite capabilities.
 	// The returned Face will be used to load Graphite tables.
 	// Overide this method to disable Graphite functionalities.
-	IsGraphite() (bool, *Face)
+	IsGraphite() (*Face, bool)
 }
 
 // Face is the in-memory representation of a font file (.ttf, .otf)

--- a/opentype/opentype.go
+++ b/opentype/opentype.go
@@ -35,7 +35,7 @@ type Face struct{}
 type TableFvar struct{}
 
 // TablesLayout exposes advanced layout tables.
-// All the fields are optionnals, since a font may only provide a subset of these tables.
+// All the fields are optionals, since a font may only provide a subset of these tables.
 type TablesLayout struct {
 	GDEF TableGDEF // An absent table has a nil Class
 	Trak TableTrak

--- a/opentype/opentype.go
+++ b/opentype/opentype.go
@@ -1,0 +1,68 @@
+// Package opentype provides an implementation of
+// font.Face for Opentype (Truetype) fonts.
+//
+// It supports advanced Opentype and AAT layout features.
+package opentype
+
+import "github.com/go-text/font"
+
+// var _ FaceOpentype = (*Face)(nil)
+
+// FaceOpentype is a specialization of font.Face for Opentype
+// font files.
+type FaceOpentype interface {
+	font.Face
+
+	// TablesLayout fetches the advanced Opentype and AAT layout tables of the font.
+	TablesLayout() TablesLayout
+
+	// Variations returns the variations for the font,
+	// or an empty table.
+	Variations() TableFvar
+
+	// IsGraphite returns true if the font has Graphite capabilities.
+	// The returned Face will be used to load Graphite tables.
+	// Overide this method to disable Graphite functionalities.
+	IsGraphite() (bool, *Face)
+}
+
+// Face is the in-memory representation of a font file (.ttf, .otf)
+// or an element of a font collection (.ttc, .otc, .dfont)
+type Face struct{}
+
+// TableFvar is the font variations table
+// (https://docs.microsoft.com/typography/opentype/spec/fvar)
+type TableFvar struct{}
+
+// TablesLayout exposes advanced layout tables.
+// All the fields are optionnals, since a font may only provide a subset of these tables.
+type TablesLayout struct {
+	GDEF TableGDEF // An absent table has a nil Class
+	Trak TableTrak
+	Ankr TableAnkr
+	Feat TableFeat
+	Morx TableMorx
+	Kern TableKernx
+	Kerx TableKernx
+	GSUB TableGSUB // An absent table has a nil slice of lookups
+	GPOS TableGPOS // An absent table has a nil slice of lookups
+}
+
+type (
+	// https://docs.microsoft.com/typography/opentype/spec/gdef
+	TableGDEF struct{}
+	// https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6trak.html
+	TableTrak struct{}
+	// https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6ankr.html
+	TableAnkr struct{}
+	// https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6feat.html
+	TableFeat struct{}
+	// https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6morx.html
+	TableMorx struct{}
+	// https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6kerx.html
+	TableKernx struct{}
+	// https://docs.microsoft.com/typography/opentype/spec/gsub
+	TableGSUB struct{}
+	// https://docs.microsoft.com/typography/opentype/spec/gpos
+	TableGPOS struct{}
+)


### PR DESCRIPTION
This is a sketch of a possible font interface. The common interface may be implemented by the "simple" font formats like Type1 and bitmap. The opentype.FaceOpentype would be use by the shaper (Harfbuzz) for Opentype font files.

This package could also provide a way to render glyphs (it's the purpose of the FaceRenderer interface), but I've not thought about it yet.