### PR TITLE
Add glyph lookup support

### DIFF
--- a/face.go
+++ b/face.go
@@ -2,8 +2,13 @@ package font
 
 import "github.com/benoitkugler/textlayout/fonts"
 
+// make sure that we can use textlayout/fonts.Face as Face
+var _ Face = (fonts.Face)(nil)
+
+type GID = fonts.GID
+
 type Face interface {
-	// NominalGlyph returns the glyph used to represent the given rune,
-	// or false the rune is not supported.
-	NominalGlyph(r rune) (fonts.GID, bool)
+	// NominalGlyph returns the glyph identifier used to represent the given rune,
+	// or false the rune is not supported by the font.
+	NominalGlyph(r rune) (GID, bool)
 }

--- a/face.go
+++ b/face.go
@@ -1,3 +1,9 @@
 package font
 
-type Face interface{}
+import "github.com/benoitkugler/textlayout/fonts"
+
+type Face interface {
+	// NominalGlyph returns the glyph used to represent the given rune,
+	// or false the rune is not supported.
+	NominalGlyph(r rune) (fonts.GID, bool)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/go-text/font
 
 go 1.15
+
+require github.com/benoitkugler/textlayout v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/benoitkugler/pstokenizer v1.0.0/go.mod h1:l1G2Voirz0q/jj0TQfabNxVsa8HZXh/VMxFSRALWTiE=
+github.com/benoitkugler/textlayout v0.0.3 h1:r/PmSx9+MoFr0JkJjWu9XeU04caWg6pzqSGLXzkrdHY=
+github.com/benoitkugler/textlayout v0.0.3/go.mod h1:puH4v13Uz7uIhIH0XMk5jgc8U3MXcn5r3VlV9K8n0D8=
+golang.org/x/image v0.0.0-20210504121937-7319ad40d33e/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
Implementing https://github.com/go-text/shaping/issues/8 requires to know the runes supported by a font.
I then propose to add the NominalGlyph method (which is usually implemented by looking in the cmap table).
